### PR TITLE
Use application repo for list_tenants

### DIFF
--- a/lib/tenantex.ex
+++ b/lib/tenantex.ex
@@ -45,11 +45,7 @@ defmodule Tenantex do
 
   def get_repo_adapter do
     get_appname()
-    |> Application.get_env(
-      get_appname()
-      |> Application.get_env(:ecto_repos)
-      |> List.first()
-    )
+    |> Application.get_env(get_repo())
     |> Keyword.fetch!(:adapter)
   end
 end

--- a/lib/tenantex.ex
+++ b/lib/tenantex.ex
@@ -5,7 +5,14 @@ defmodule Tenantex do
   defdelegate drop_tenant(repo, tenant), to: Tenantex.Repo
   defdelegate new_tenant(repo, tenant), to: Tenantex.Repo
 
-  def list_tenants, do: list_tenants(Application.get_env(:tenantex, Tenantex)[:tenants])
+  def list_tenants do
+    Mix.Project.config()[:app]
+      |> Application.get_env(:ecto_repos)
+      |> List.first()
+      |> Ecto.Adapters.SQL.query!("select schema_name from information_schema.schemata")
+      |> Map.fetch!(:rows)
+      |> Enum.filter_map(fn(schema) -> String.starts_with?(List.first(schema),Application.get_env(:tenantex, Tenantex)[:schema_prefix]) end, &(List.first(&1)) )
+  end
   defp list_tenants({module, func}), do: apply(module, func, [])
   defp list_tenants({module, func, args}), do: apply(module, func, args)
   defp list_tenants(tenants) when is_list(tenants), do: tenants

--- a/lib/tenantex.ex
+++ b/lib/tenantex.ex
@@ -1,4 +1,6 @@
 defmodule Tenantex do
+  import Application, only: [get_env: 2]
+
   defmodule TenantMissingError do
     defexception message: "No tenant specified"
   end
@@ -6,14 +8,48 @@ defmodule Tenantex do
   defdelegate new_tenant(repo, tenant), to: Tenantex.Repo
 
   def list_tenants do
-    Mix.Project.config()[:app]
+    statement = case get_repo_adapter() do
+      Ecto.Adapters.Postgres ->
+        "SELECT schema_name FROM information_schema.schemata"
+      Ecto.Adapters.MySQL ->
+        "SHOW DATABASES LIKE '" <> get_prefix() <> "%'"
+      Ecto.Adapters.SQL ->
+        ""
+    end
+    get_repo()
+    |> Ecto.Adapters.SQL.query!(statement)
+    |> Map.fetch!(:rows)
+    |> Enum.flat_map(&(&1))
+    |> Enum.filter(&(String.starts_with?(&1, get_prefix())))
+  end
+
+  defp get_prefix, do: get_env(:tenantex, Tenantex)[:schema_prefix] || "tenant_"
+  
+  defp get_repo do
+    case get_env(:tenantex, Tenantex)[:repo] do
+      nil -> default_repo()
+      repo -> repo
+    end
+  end
+  
+  defp get_appname do
+    Mix.Project.config()
+    |> Keyword.fetch!(:app)
+  end
+
+  def default_repo do
+    get_appname()
+    |> Application.get_env(:ecto_repos)
+    |> List.first()    
+  end
+
+  def get_repo_adapter do
+    get_appname()
+    |> Application.get_env(
+      get_appname()
       |> Application.get_env(:ecto_repos)
       |> List.first()
-      |> Ecto.Adapters.SQL.query!("select schema_name from information_schema.schemata")
-      |> Map.fetch!(:rows)
-      |> Enum.filter_map(fn(schema) -> String.starts_with?(List.first(schema),Application.get_env(:tenantex, Tenantex)[:schema_prefix]) end, &(List.first(&1)) )
+    )
+    |> Keyword.fetch!(:adapter)
   end
-  defp list_tenants({module, func}), do: apply(module, func, [])
-  defp list_tenants({module, func, args}), do: apply(module, func, args)
-  defp list_tenants(tenants) when is_list(tenants), do: tenants
 end


### PR DESCRIPTION
Get the live schema list from the db in order to resolve for list_tenants()
Utilize app configs as well as Tenantex :schema_prefix config to filter the schemas known to the db
Very large assumption here that the config for :ecto_repos is a single element list
Alternative would be to more directly assign the relevant repo name in another config option for Tenantex