### PR TITLE
Remove schema_name from map of tenants

### DIFF
--- a/lib/mix/tasks/tenantex.migrate.ex
+++ b/lib/mix/tasks/tenantex.migrate.ex
@@ -27,7 +27,6 @@ defmodule Mix.Tasks.Tenantex.Migrate do
 
     Mix.Task.run "loadpaths", []
     Tenantex.list_tenants
-    |> Enum.map(&schema_name(&1))
     |> Enum.each(&migrator.(args, &1))
   end
 


### PR DESCRIPTION
No need to add the prefix to the tenants list anymore