### PR TITLE
Fixed migrations. 

### DIFF
--- a/lib/mix/tasks/tenantex.migrate.ex
+++ b/lib/mix/tasks/tenantex.migrate.ex
@@ -1,5 +1,6 @@
 defmodule Mix.Tasks.Tenantex.Migrate do
   use Mix.Task
+  import Mix.Ecto
   import Mix.Tenantex
   @shortdoc "Migrates every tenant defined in your database"
 
@@ -16,14 +17,29 @@ defmodule Mix.Tasks.Tenantex.Migrate do
 
   """
 
-  def run(args, migrator \\ &Mix.Tasks.Tenantex.Migrate.migrate_with_prefix/2) do
+  def run(args, migrator \\ &__MODULE__.migrate_with_prefix/2) do
     # Because migrations are loaded at run-time for each migration, warnings
     # about duplicate module definitions will happen for each tenant after the first
     # one. This silences that warning
-    Code.compiler_options(ignore_module_conflict: true)
 
-    Mix.Task.run "loadpaths", []
-    Tenantex.list_tenants
+    Code.compiler_options(ignore_module_conflict: true)
+    repo = Tenantex.get_repo()
+    ensure_repo(repo, args)
+    {:ok, pid, _apps} = ensure_started(repo, [])
+    sandbox? = repo.config[:pool] == Ecto.Adapters.SQL.Sandbox
+
+    # If the pool is Ecto.Adapters.SQL.Sandbox,
+    # let's make sure we get a connection outside of a sandbox.
+    if sandbox? do
+      Ecto.Adapters.SQL.Sandbox.checkin(repo)
+      Ecto.Adapters.SQL.Sandbox.checkout(repo, sandbox: false)
+    end
+
+    tenants = Tenantex.list_tenants
+    pid && repo.stop(pid)
+
+    # Now run the migrations
+    tenants
     |> Enum.each(&migrator.(args, &1))
   end
 

--- a/lib/tenantex.ex
+++ b/lib/tenantex.ex
@@ -5,5 +5,5 @@ defmodule Tenantex do
   defdelegate drop_tenant(tenant), to: Tenantex.Repo
   defdelegate new_tenant(tenant), to: Tenantex.Repo
   defdelegate list_tenants(), to: Tenantex.Repo
-  
+  defdelegate get_repo(), to: Tenantex.Repo
 end

--- a/lib/tenantex/repo.ex
+++ b/lib/tenantex/repo.ex
@@ -234,21 +234,10 @@ defmodule Tenantex.Repo do
     |> Enum.filter(&(String.starts_with?(&1, get_prefix())))
   end
 
-  defp get_repo do
+  def get_repo do
     case get_env(:tenantex, Tenantex)[:repo] do
-      nil -> default_repo()
+      nil -> Mix.Ecto.parse_repo([]) |> hd
       repo -> repo
     end
-  end
-
-  defp get_appname do
-    Mix.Project.config()
-    |> Keyword.fetch!(:app)
-  end
-
-  defp default_repo do
-    get_appname()
-    |> get_env(:ecto_repos)
-    |> List.first()
   end
 end


### PR DESCRIPTION
New change to auto-infer tenants caused a break, because the repo wasn’t started yet before they were queried.  Tests missed it because they start the repo at the beginning.

@jbsmith - I was pulling functionality from Mix.Ecto anyway, so I thought I'd simplify some of the get_repo code.  Thought I'd check and see if you had any concerns.