### PR TITLE
Embed ecto repository priv path construction

### DIFF
--- a/lib/mix/tenantex.ex
+++ b/lib/mix/tenantex.ex
@@ -1,11 +1,11 @@
 defmodule Mix.Tenantex do
-  import Mix.Ecto, only: [source_repo_priv: 1]
-
   @doc """
   Gets the migrations path from a repository.
   """
   @spec tenant_migrations_path(Ecto.Repo.t) :: String.t
   def tenant_migrations_path(repo) do
-    Path.join(source_repo_priv(repo), "tenant_migrations")
+    repo_priv = repo.config()[:priv] || "priv/#{repo |> Module.split |> List.last |> Macro.underscore}"
+    repo_priv_fullpath = Application.app_dir(Keyword.fetch!(repo.config(), :otp_app), repo_priv)
+    Path.join(repo_priv_fullpath, "tenant_migrations")
   end
 end

--- a/test/lib/mix/tenantex_test.exs
+++ b/test/lib/mix/tenantex_test.exs
@@ -1,0 +1,10 @@
+defmodule Mix.TenantexTest do
+  use ExUnit.Case
+  alias Tenantex.Test.TenantedRepo
+
+  test ".tenant_migrations_path/1" do
+    path = Mix.Tenantex.tenant_migrations_path(TenantedRepo)
+    assert String.starts_with?(path, File.cwd!())
+    assert String.ends_with?(path, "/priv/tenanted_repo/tenant_migrations")
+  end
+end


### PR DESCRIPTION
Because current ecto version uses Mix.Project.deps_paths for it, which is not available in production.