### PR TITLE
Fix README instructions to set the tenant prefix correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ database for MySQL
 ```elixir
 {:tenantex, "~> 0.1.0"}
 ```
-- Run mix deps.get && mix deps.compile
+- Run
+```mix deps.get && mix deps.compile```
 
 - You can also configure your tenant schema prefix, adding this to your application configs:
 ```elixir
-config :tenantex, schema_prefix: "prefix_" # the default prefix is "tenant_"
+config :tenantex, Tenantex, schema_prefix: "prefix_" # the default prefix is "tenant_"
 ```
 
 ### Use


### PR DESCRIPTION
Just an update in the README to configure tenant schema prefix.